### PR TITLE
docs: fix a couple of typos

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -148,10 +148,10 @@ ASF.json
 | `REMOVEDEMO [Bots]`                 |           |            | Same as `REMOVEDEMOS`                           |
 | `REMOVELICENSES [Bots] <SubIDs>`    | `RL`      | `Master`   | Remove bot's licenses with the specified subIDs |
 | `REMOVELICENSE [Bots] <SubIDs>`     |           |            | Same as `REMOVELICENSES`                        |
-| `EMAILIOPTIONS [Bots]`              | `EO`      | `Operator` | Get bot's email preferences                     |
-| `EMAILIOPTION [Bots]`               |           |            | Same as `EMAILIOPTIONS`                         |
-| `SETEMAILIOPTIONS [Bots] <Options>` | `SEO`     | `Master`   | Set bot's email preferences                     |
-| `SETEMAILIOPTION [Bots] <Options>`  |           |            | Same as `SETEMAILIOPTIONS`                      |
+| `EMAILOPTIONS [Bots]`               | `EO`      | `Operator` | Get bot's email preferences                     |
+| `EMAILOPTION [Bots]`                |           |            | Same as `EMAILOPTIONS`                          |
+| `SETEMAILOPTIONS [Bots] <Options>`  | `SEO`     | `Master`   | Set bot's email preferences                     |
+| `SETEMAILOPTION [Bots] <Options>`   |           |            | Same as `SETEMAILOPTIONS`                       |
 
 - `SETEMAILOPTION` arguments explanation
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ ASF.json
 | `REMOVELICENSES [Bots] <SubIDs>`    | `RL`  | `Master`   | 移除账户中指定的 Sub License      |
 | `REMOVELICENSE [Bots] <SubIDs>`     |       |            | 同 `REMOVELICENSES`               |
 | `EMAILIOPTIONS [Bots]`              | `EO`  | `Operator` | 读取账户中的电子邮件偏好选项      |
-| `EMAILIOPTION [Bots]`               |       |            | 同 `EMAILIOPTIONS`                |
-| `SETEMAILIOPTIONS [Bots] <Options>` | `SEO` | `Master`   | 设置账户中的电子邮件偏好选项      |
-| `SETEMAILIOPTION [Bots] <Options>`  |       |            | 同 `SETEMAILIOPTIONS`             |
+| `EMAILIOPTION [Bots]`               |       |            | 同 `EMAILOPTIONS`                 |
+| `SETEMAILOPTIONS [Bots] <Options>`  | `SEO` | `Master`   | 设置账户中的电子邮件偏好选项      |
+| `SETEMAILOPTION [Bots] <Options>`   |       |            | 同 `SETEMAILOPTIONS`              |
 
 - `SETEMAILOPTIONS` 参数说明
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -151,8 +151,8 @@ ASF.json
 | `REMOVELICENSE [Bots] <SubIDs>`     |            |            | То же, что и `REMOVELICENSES`                |
 | `EMAILIOPTIONS [Bots]`              | `EO`       | `Operator` | Выводит настройки рассылки бота              |
 | `EMAILIOPTION [Bots]`               |            |            | То же, что и `EMAILIOPTIONS`                 |
-| `SETEMAILIOPTIONS [Bots] <Options>` | `SEO`      | `Master`   | Изменяет настройки рассылки                  |
-| `SETEMAILIOPTION [Bots] <Options>`  |            |            | То же, что и `SETEMAILIOPTIONS`              |
+| `SETEMAILOPTIONS [Bots] <Options>`  | `SEO`      | `Master`   | Изменяет настройки рассылки                  |
+| `SETEMAILOPTION [Bots] <Options>`   |            |            | То же, что и `SETEMAILOPTIONS`               |
 
 - `SETEMAILOPTION` значения аргументов
 


### PR DESCRIPTION
`SETEMAILIOPTION` -> `SETEMAILOPTION`
`SETEMAILIOPTIONS` -> `SETEMAILOPTIONS`